### PR TITLE
feat: implement SSM

### DIFF
--- a/test/ssm.test.ts
+++ b/test/ssm.test.ts
@@ -1,0 +1,13 @@
+import { AWS } from "../src";
+
+process.env.AWS_REGION = "us-west-2";
+
+const client = new AWS.SSM();
+
+test("get parameter", async () => {
+  const response = await client.getParameter({
+    Name: "my-parameter",
+  });
+
+  expect(response.Parameter?.Value).toEqual("test");
+});


### PR DESCRIPTION
Closes #5 

With this one, learned about the API reference some times containing examples API requests including all the headers which is helpful: https://docs.aws.amazon.com/systems-manager/latest/APIReference/API_GetParameter.html

Also learned about the various content types for JSON which is annoying. I wonder how many permutations are required here:

```ts

const contentTypeMap: Partial<Record<keyof SDK, string>> = {
  DynamoDB: "application/x-amz-json-1.0",
  SSM: "application/x-amz-json-1.1",
};
```

Should look into generating these look up tables from a manifest, as suggested here: https://twitter.com/jenschude/status/1615373732926656518?s=20&t=FWEvbqlfpTbT0Cn0q8AvYA