### PR TITLE
feat: set up repeatable test and improve error

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "itty-aws",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "files": [
     "lib"
   ],
@@ -10,7 +10,7 @@
   "scripts": {
     "gen": "ts-node-esm ./scripts/gen-sdk-types.mts",
     "build": "tsc -b",
-    "test": "NODE_OPTIONS=--experimental-vm-modules jest",
+    "test": "ts-node-esm --project ./tsconfig.esm.json ./test/setup.ts && NODE_OPTIONS=--experimental-vm-modules jest",
     "watch": "tsc -b -w",
     "analyze:bundle": "sh ./scripts/analyze-bundle.sh",
     "bench:synth": "pnpm -r --filter @benchmark/infra synth",

--- a/src/index.ts
+++ b/src/index.ts
@@ -74,7 +74,7 @@ export const AWS: SDK = new Proxy({} as any, {
                   // for now we'll just throw the error as a json object
                   // TODO: throw something that is easy to branch on and check instanceof - this may increase bundle size though
                   throw isJson
-                    ? await response.json()
+                    ? new AWSError(await response.json())
                     : new Error(await response.text());
                 }
               };
@@ -85,6 +85,14 @@ export const AWS: SDK = new Proxy({} as any, {
     };
   },
 });
+
+export class AWSError extends Error {
+  readonly type: string;
+  constructor(error: any) {
+    super(typeof error?.message === "string" ? error.message : error.__type);
+    this.type = error.__type;
+  }
+}
 
 const contentTypeMap: Partial<Record<keyof SDK, string>> = {
   DynamoDB: "application/x-amz-json-1.0",

--- a/test/constants.ts
+++ b/test/constants.ts
@@ -1,0 +1,7 @@
+export const TableName = "itty-test-table";
+
+export const SsmParameterName = "itty-parameter-name";
+
+export const SsmParameterValue = "itty-parameter-value";
+
+process.env.AWS_REGION = "us-west-2";

--- a/test/dynamodb.test.ts
+++ b/test/dynamodb.test.ts
@@ -1,10 +1,7 @@
 import { AWS } from "../src";
-
-process.env.AWS_REGION = "us-west-2";
+import { TableName } from "./constants";
 
 const ddb = new AWS.DynamoDB();
-
-const TableName = "MY_TABLE";
 
 test("DynamoDB PutItem and GetItem should work", async () => {
   const Item = {

--- a/test/ssm.test.ts
+++ b/test/ssm.test.ts
@@ -1,13 +1,12 @@
 import { AWS } from "../src";
-
-process.env.AWS_REGION = "us-west-2";
+import { SsmParameterName, SsmParameterValue } from "./constants";
 
 const client = new AWS.SSM();
 
 test("get parameter", async () => {
   const response = await client.getParameter({
-    Name: "my-parameter",
+    Name: SsmParameterName,
   });
 
-  expect(response.Parameter?.Value).toEqual("test");
+  expect(response.Parameter?.Value).toEqual(SsmParameterValue);
 });

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -5,6 +5,7 @@
     "declarationMap": true,
     "esModuleInterop": true,
     "moduleResolution": "NodeNext",
+    "target": "ES2022",
     "module": "esnext",
     "lib": ["ES2022"],
     "types": ["@types/node", "@types/jest"]


### PR DESCRIPTION
This sets up a script that will run before jest does and create all the necessary AWS resources required by the tests. Resources are created using itty-aws ;)

I also added an `AWSError` class - throwing the JSON object lost the stack trace so we needed class that that extends `Error`. Tracking #10 for better error support that is comparable to V3 SDK.