### PR TITLE
fix: ec2Query input transformation bug

### DIFF
--- a/src/protocols/ec2-query.ts
+++ b/src/protocols/ec2-query.ts
@@ -17,6 +17,10 @@ function safeParseXml(xmlText: string): any {
   }
 }
 
+function capitalizeFirst(str: string): string {
+  return str.charAt(0).toUpperCase() + str.slice(1);
+}
+
 function toParams(
   shapes: Record<string, any>,
   shapeId: string,
@@ -31,7 +35,8 @@ function toParams(
     case "structure": {
       if (value == null) return;
       for (const [memberName, member] of Object.entries(shape.members ?? {})) {
-        const fieldName = (member as any).locationName ?? memberName;
+        const rawFieldName = (member as any).locationName ?? memberName;
+        const fieldName = capitalizeFirst(rawFieldName);
         const nextPrefix = prefix ? `${prefix}.${fieldName}` : fieldName;
         toParams(
           shapes,

--- a/src/protocols/ec2-query.ts
+++ b/src/protocols/ec2-query.ts
@@ -1,17 +1,6 @@
 import { XMLParser } from "fast-xml-parser";
+import { ec2ModelMeta } from "../ec2-metadata.ts";
 import type { ProtocolHandler, ServiceMetadata } from "./interface.ts";
-
-// Lazy-loaded EC2 metadata for tree-shaking
-let ec2ModelMeta: any = null;
-
-// Synchronous lazy loader - only loads metadata when first accessed
-function getEc2ModelMeta() {
-  if (!ec2ModelMeta) {
-    // Use require() for synchronous dynamic loading
-    ec2ModelMeta = require("../ec2-metadata.js").ec2ModelMeta;
-  }
-  return ec2ModelMeta;
-}
 
 const xmlParser = new XMLParser({
   ignoreAttributes: true,
@@ -62,9 +51,8 @@ function toParams(
       const flattened = shape.member?.flattened || shape.flattened;
       value.forEach((item, i) => {
         const idx = i + 1;
-        const base = flattened
-          ? `${prefix}.${idx}` // e.g., "GroupId.1"
-          : `${prefix}.${memberName}.${idx}`; // e.g., "TagSet.member.1"
+        // For EC2 Query, most lists are flattened and use the prefix directly
+        const base = `${prefix}.${idx}`;
         toParams(shapes, shape.member!.target, item, base, out);
       });
       break;
@@ -209,7 +197,7 @@ export class Ec2QueryHandler implements ProtocolHandler {
     params.append("Version", "2016-11-15");
 
     // Use enhanced flattening with metadata (lazy-loaded)
-    const modelMeta = getEc2ModelMeta();
+    const modelMeta = ec2ModelMeta;
     const op = modelMeta.operations[action];
     if (op) {
       const enhancedParams: Record<string, string> = {
@@ -258,12 +246,11 @@ export class Ec2QueryHandler implements ProtocolHandler {
 
     if (wrapperName) {
       const opName = wrapperName.replace(/Response$/, "");
-      const modelMeta = getEc2ModelMeta();
-      const opMeta = modelMeta.operations[opName];
+      const opMeta = ec2ModelMeta.operations[opName];
       const outShape = opMeta?.output;
 
       if (outShape) {
-        return fromXml(modelMeta.shapes, outShape, payloadNode);
+        return fromXml(ec2ModelMeta.shapes, outShape, payloadNode);
       }
     }
 

--- a/test/smoke/ec2.test.ts
+++ b/test/smoke/ec2.test.ts
@@ -1,0 +1,162 @@
+import { describe, expect, it } from "@effect/vitest";
+import { Console, Effect } from "effect";
+import { AWS } from "../../src/index.ts";
+
+describe("EC2 Smoke Tests", () => {
+  const client = new AWS.EC2({ region: "us-east-1" });
+
+  it.effect(
+    "should perform complete VPC lifecycle: create VPC, wait for available, delete VPC, and verify deletion",
+    () =>
+      Effect.gen(function* () {
+        const timestamp = Date.now();
+        const vpcName = `test-vpc-${timestamp}`;
+
+        yield* Console.log(`Starting EC2 smoke test with VPC: ${vpcName}`);
+
+        // Step 1: Create VPC
+        yield* Console.log("Step 1: Creating VPC...");
+
+        const createResult = yield* client.createVpc({
+          CidrBlock: "10.0.0.0/16",
+          TagSpecifications: [
+            {
+              ResourceType: "vpc",
+              Tags: [{ Key: "Name", Value: vpcName }],
+            },
+          ],
+        });
+
+        const vpcId = createResult.Vpc?.VpcId;
+        expect(vpcId).toBeDefined();
+        expect(createResult.Vpc?.CidrBlock).toBe("10.0.0.0/16");
+
+        yield* Console.log(`Created VPC with ID: ${vpcId}`);
+
+        // Step 2: Wait for VPC to become available
+        yield* Console.log("Step 2: Waiting for VPC to become available...");
+
+        const waitAttempts = 30; // ~60s
+        let ready = false;
+        for (let i = 0; i < waitAttempts; i++) {
+          const describeResult = yield* client.describeVpcs({ VpcIds: [vpcId!] });
+          const state = describeResult.Vpcs?.[0]?.State;
+
+          yield* Console.log(`VPC state check ${i + 1}/${waitAttempts}: ${state}`);
+
+          if (state === "available") {
+            ready = true;
+            break;
+          }
+          if (state !== "pending") {
+            throw new Error(`Unexpected VPC state: ${state}`);
+          }
+          yield* Effect.sleep(2000);
+        }
+
+        expect(ready).toBe(true);
+        yield* Console.log("VPC is now available");
+
+        // Step 3: Delete VPC
+        yield* Console.log("Step 3: Deleting VPC...");
+
+        yield* client.deleteVpc({ VpcId: vpcId! });
+        yield* Console.log("Delete VPC request sent");
+
+        // Step 4: Verify VPC deletion
+        yield* Console.log("Step 4: Verifying VPC deletion...");
+
+        const verifyAttempts = 30; // ~60s
+        let deleted = false;
+        for (let i = 0; i < verifyAttempts; i++) {
+          const deleteCheck = yield* client
+            .describeVpcs({ VpcIds: [vpcId!] })
+            .pipe(
+              Effect.map((result) => ({
+                deleted: result.Vpcs?.length === 0,
+                error: null,
+              })),
+              Effect.catchAll((error: any) => {
+                const code = error?.name ?? error?.Code ?? error?.code;
+                return Effect.succeed({
+                  deleted: code === "InvalidVpcID.NotFound",
+                  error: code,
+                });
+              }),
+            );
+
+          yield* Console.log(
+            `Deletion check ${i + 1}/${verifyAttempts}: deleted=${deleteCheck.deleted}, error=${deleteCheck.error}`,
+          );
+
+          if (deleteCheck.deleted) {
+            deleted = true;
+            break;
+          }
+          yield* Effect.sleep(2000);
+        }
+
+        expect(deleted).toBe(true);
+        yield* Console.log("VPC successfully deleted");
+
+        yield* Console.log("EC2 smoke test completed successfully!");
+
+        return { vpcId, ready, deleted };
+      }),
+    { timeout: 180000 }, // 3 minutes timeout for VPC operations
+  );
+
+  it.effect(
+    "should handle non-existent VPC gracefully",
+    () =>
+      Effect.gen(function* () {
+        const nonExistentVpcId = `vpc-${Math.random().toString(36).substr(2, 9)}`;
+
+        const result = yield* client
+          .describeVpcs({
+            VpcIds: [nonExistentVpcId],
+          })
+          .pipe(
+            Effect.map(() => ({
+              exists: true,
+              error: undefined,
+            })),
+            Effect.catchAll((error: any) => {
+              const code = error?.name ?? error?.Code ?? error?.code;
+              return Effect.succeed({
+                exists: false,
+                error: code,
+              });
+            }),
+          );
+
+        expect(result.exists).toBe(false);
+        expect(result.error).toBe("InvalidVpcID.NotFound");
+      }),
+    { timeout: 10000 },
+  );
+
+  it.effect(
+    "should handle invalid CIDR block gracefully",
+    () =>
+      Effect.gen(function* () {
+        const result = yield* client
+          .createVpc({
+            CidrBlock: "invalid-cidr", // Invalid CIDR block
+          })
+          .pipe(
+            Effect.map(() => ({ success: true, error: undefined })),
+            Effect.catchAll((error: any) =>
+              Effect.succeed({
+                success: false,
+                error: error._tag || error?.name || error?.Code || "UnknownError",
+              }),
+            ),
+          );
+
+        expect(result.success).toBe(false);
+        expect(result.error).toBeDefined();
+      }),
+    { timeout: 10000 },
+  );
+});


### PR DESCRIPTION
Fixes a bug in EC2 Query protocol input transformation where field names and list flattening weren't handled correctly.

  Changes:
  - Fixed field name capitalization for EC2 Query parameters
  - Simplified list flattening to use correct index format (prefix.1, prefix.2)
  - Removed lazy metadata loading in favor of direct import
  - Added comprehensive EC2 smoke tests covering VPC lifecycle operations

  Test Coverage:
  - VPC creation, state monitoring, and deletion
  - Error handling for non-existent resources
  - Invalid parameter validation